### PR TITLE
Fix sonar issue s1155 'Collection.isEmpty()' should be used to test for emptiness

### DIFF
--- a/sorm4j/src/main/java/org/nkjmlab/sorm4j/extension/h2/commands/ScriptSql.java
+++ b/sorm4j/src/main/java/org/nkjmlab/sorm4j/extension/h2/commands/ScriptSql.java
@@ -118,11 +118,11 @@ public class ScriptSql {
         }
       }
 
-      if (tables.size() != 0) {
+      if (!tables.isEmpty()) {
         ret.add("table");
         ret.add(String.join(",", tables));
       }
-      if (schemas.size() != 0) {
+      if (!schemas.isEmpty()) {
         ret.add("schema");
         ret.add(String.join(",", schemas));
       }

--- a/sorm4j/src/main/java/org/nkjmlab/sorm4j/internal/context/logging/LogContextImpl.java
+++ b/sorm4j/src/main/java/org/nkjmlab/sorm4j/internal/context/logging/LogContextImpl.java
@@ -25,7 +25,7 @@ public class LogContextImpl implements LogContext {
       Supplier<SormLogger> loggerSupplier, Set<LogContext.Category> enabledCategories) {
     this.loggerSupplier = loggerSupplier != null ? loggerSupplier : getDefaultLoggerSupplier();
     this.enabledCategories =
-        enabledCategories.size() == 0 ? Collections.emptySet() : EnumSet.copyOf(enabledCategories);
+        enabledCategories.isEmpty() ? Collections.emptySet() : EnumSet.copyOf(enabledCategories);
   }
 
   public static Supplier<SormLogger> getDefaultLoggerSupplier() {

--- a/sorm4j/src/main/java/org/nkjmlab/sorm4j/table/definition/TableDefinition.java
+++ b/sorm4j/src/main/java/org/nkjmlab/sorm4j/table/definition/TableDefinition.java
@@ -313,7 +313,7 @@ public interface TableDefinition {
     }
 
     private static String createUniqueConstraint(List<String[]> uniqueColumnPairs) {
-      return (uniqueColumnPairs == null || uniqueColumnPairs.size() == 0)
+      return (uniqueColumnPairs == null || uniqueColumnPairs.isEmpty())
           ? ""
           : ", "
               + String.join(
@@ -324,7 +324,7 @@ public interface TableDefinition {
     }
 
     private static String createCheckConstraint(List<String> checkConditions) {
-      return (checkConditions == null || checkConditions.size() == 0)
+      return (checkConditions == null || checkConditions.isEmpty())
           ? ""
           : ", "
               + String.join(


### PR DESCRIPTION

We propose the fix to violation s1155 "Collection.isEmpty() should be used to test for emptiness" identified by SonarQube.

When you call isEmpty(), it clearly communicates the code’s intention, which is to check if the collection is empty. Using size() == 0 for this purpose is less direct and makes the code slightly more complex.
Moreover, depending on the implementation, the size() method can have a time complexity of O(n) where n is the number of elements in the collection. On the other hand, isEmpty() simply checks if there is at least one element in the collection, which is a constant time operation, O(1).

This patch has been automatically produced by our java code remediation solution, available free of charge for all open source projects (https://www.indepth.fr/).

We believe that this PR can improve the quality of your project code to a certain extent. Your feedback will also be very useful for us to know if our solution produces quality code or if we need to improve the way it works.

Thank you for your feedback.